### PR TITLE
Do not add the public key more than once

### DIFF
--- a/centos/init.sh
+++ b/centos/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $PUBLIC_KEY >> /root/.ssh/authorized_keys
+grep -qF -- "$PUBLIC_KEY" /root/.ssh/authorized_keys || echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
 if [ -x /opt/mistio-collectd/collectd.sh ]; then
     /opt/mistio-collectd/collectd.sh start
 fi

--- a/debian-wheezy/init.sh
+++ b/debian-wheezy/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $PUBLIC_KEY >> /root/.ssh/authorized_keys
+grep -qF -- "$PUBLIC_KEY" /root/.ssh/authorized_keys || echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
 if [ -x /opt/mistio-collectd/collectd.sh ]; then
     /opt/mistio-collectd/collectd.sh start
 fi

--- a/fedora-20/init.sh
+++ b/fedora-20/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $PUBLIC_KEY >> /root/.ssh/authorized_keys
+grep -qF -- "$PUBLIC_KEY" /root/.ssh/authorized_keys || echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
 if [ -x /opt/mistio-collectd/collectd.sh ]; then
     /opt/mistio-collectd/collectd.sh start
 fi

--- a/opensuse-13.1/init.sh
+++ b/opensuse-13.1/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $PUBLIC_KEY >> /root/.ssh/authorized_keys
+grep -qF -- "$PUBLIC_KEY" /root/.ssh/authorized_keys || echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
 if [ -x /opt/mistio-collectd/collectd.sh ]; then
     /opt/mistio-collectd/collectd.sh start
 fi

--- a/ubuntu-14.04/init.sh
+++ b/ubuntu-14.04/init.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-echo $PUBLIC_KEY >> /root/.ssh/authorized_keys
+grep -qF -- "$PUBLIC_KEY" /root/.ssh/authorized_keys || echo "$PUBLIC_KEY" >> /root/.ssh/authorized_keys
 if [ -x /opt/mistio-collectd/collectd.sh ]; then
     /opt/mistio-collectd/collectd.sh start
 fi


### PR DESCRIPTION
The current *init.sh* script adds the public key to the *authorized_keys* file on every start. This commit makes sure it is not added again when it is already present.